### PR TITLE
Check for null if Youtube is not installed

### DIFF
--- a/platforms/android/src/com/bunkerpalace/cordova/YoutubeVideoPlayer.java
+++ b/platforms/android/src/com/bunkerpalace/cordova/YoutubeVideoPlayer.java
@@ -51,7 +51,7 @@ public class YoutubeVideoPlayer extends CordovaPlugin {
 			Intent intent;
 			Context cordovaContext = cordova.getActivity();
 			String version = YouTubeIntents.getInstalledYouTubeVersionName(cordovaContext);
-			if(version.startsWith("11.16") && YouTubeIntents.canResolvePlayVideoIntent(cordovaContext)) {
+			if(version != null && version.startsWith("11.16") && YouTubeIntents.canResolvePlayVideoIntent(cordovaContext)) {
 				intent = YouTubeIntents.createPlayVideoIntent(cordovaContext, videoId);
 			} else {
 				if(YouTubeIntents.canResolvePlayVideoIntentWithOptions(cordovaContext)){


### PR DESCRIPTION
Added check for null response of YouTubeIntents.getInstalledYouTubeVersionName().

https://developers.google.com/youtube/android/player/reference/com/google/android/youtube/player/YouTubeIntents#getInstalledYouTubeVersionName(android.content.Context) 
> A string representation of the version of YouTube installed on this device or null if YouTube is not installed.